### PR TITLE
Step 2 : 위치정보 확인 및 날씨 API 호출 (태태)

### DIFF
--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		827EE3F825B6802D008A35BC /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827EE3F425B6802D008A35BC /* Weather.swift */; };
 		827EE3F925B6802D008A35BC /* Temperature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827EE3F525B6802D008A35BC /* Temperature.swift */; };
 		827EE3FE25B684C0008A35BC /* ForecastList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827EE3FD25B684C0008A35BC /* ForecastList.swift */; };
+		82FD55F525BA8EA600735BBE /* InitailValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FD55F425BA8EA600735BBE /* InitailValues.swift */; };
 		C79C8CF425ADDDF200EEE3F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C8CF325ADDDF200EEE3F1 /* AppDelegate.swift */; };
 		C79C8CF625ADDDF200EEE3F1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C8CF525ADDDF200EEE3F1 /* SceneDelegate.swift */; };
 		C79C8CF825ADDDF200EEE3F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C8CF725ADDDF200EEE3F1 /* ViewController.swift */; };
@@ -45,6 +46,7 @@
 		827EE3F425B6802D008A35BC /* Weather.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		827EE3F525B6802D008A35BC /* Temperature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Temperature.swift; sourceTree = "<group>"; };
 		827EE3FD25B684C0008A35BC /* ForecastList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastList.swift; sourceTree = "<group>"; };
+		82FD55F425BA8EA600735BBE /* InitailValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitailValues.swift; sourceTree = "<group>"; };
 		C79C8CF025ADDDF200EEE3F1 /* WeatherForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79C8CF325ADDDF200EEE3F1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79C8CF525ADDDF200EEE3F1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				827EE3F425B6802D008A35BC /* Weather.swift */,
 				C79C8CF525ADDDF200EEE3F1 /* SceneDelegate.swift */,
 				C79C8CF725ADDDF200EEE3F1 /* ViewController.swift */,
+				82FD55F425BA8EA600735BBE /* InitailValues.swift */,
 				C79C8CF925ADDDF200EEE3F1 /* Main.storyboard */,
 				C79C8CFC25ADDDF300EEE3F1 /* Assets.xcassets */,
 				C79C8CFE25ADDDF300EEE3F1 /* LaunchScreen.storyboard */,
@@ -280,6 +283,7 @@
 				C79C8CF625ADDDF200EEE3F1 /* SceneDelegate.swift in Sources */,
 				827EE3F825B6802D008A35BC /* Weather.swift in Sources */,
 				827EE3F925B6802D008A35BC /* Temperature.swift in Sources */,
+				82FD55F525BA8EA600735BBE /* InitailValues.swift in Sources */,
 				827EE3F725B6802D008A35BC /* ForecastFiveDays.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		827EE3F925B6802D008A35BC /* Temperature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827EE3F525B6802D008A35BC /* Temperature.swift */; };
 		827EE3FE25B684C0008A35BC /* ForecastList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827EE3FD25B684C0008A35BC /* ForecastList.swift */; };
 		82FD55F525BA8EA600735BBE /* InitailValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FD55F425BA8EA600735BBE /* InitailValues.swift */; };
+		82FD560225BAA7D400735BBE /* URLManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FD560125BAA7D400735BBE /* URLManger.swift */; };
 		C79C8CF425ADDDF200EEE3F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C8CF325ADDDF200EEE3F1 /* AppDelegate.swift */; };
 		C79C8CF625ADDDF200EEE3F1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C8CF525ADDDF200EEE3F1 /* SceneDelegate.swift */; };
 		C79C8CF825ADDDF200EEE3F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79C8CF725ADDDF200EEE3F1 /* ViewController.swift */; };
@@ -47,6 +48,7 @@
 		827EE3F525B6802D008A35BC /* Temperature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Temperature.swift; sourceTree = "<group>"; };
 		827EE3FD25B684C0008A35BC /* ForecastList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastList.swift; sourceTree = "<group>"; };
 		82FD55F425BA8EA600735BBE /* InitailValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitailValues.swift; sourceTree = "<group>"; };
+		82FD560125BAA7D400735BBE /* URLManger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLManger.swift; sourceTree = "<group>"; };
 		C79C8CF025ADDDF200EEE3F1 /* WeatherForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79C8CF325ADDDF200EEE3F1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79C8CF525ADDDF200EEE3F1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				827EE3F425B6802D008A35BC /* Weather.swift */,
 				C79C8CF525ADDDF200EEE3F1 /* SceneDelegate.swift */,
 				C79C8CF725ADDDF200EEE3F1 /* ViewController.swift */,
+				82FD560125BAA7D400735BBE /* URLManger.swift */,
 				82FD55F425BA8EA600735BBE /* InitailValues.swift */,
 				C79C8CF925ADDDF200EEE3F1 /* Main.storyboard */,
 				C79C8CFC25ADDDF300EEE3F1 /* Assets.xcassets */,
@@ -278,6 +281,7 @@
 			files = (
 				827EE3FE25B684C0008A35BC /* ForecastList.swift in Sources */,
 				C79C8CF825ADDDF200EEE3F1 /* ViewController.swift in Sources */,
+				82FD560225BAA7D400735BBE /* URLManger.swift in Sources */,
 				C79C8CF425ADDDF200EEE3F1 /* AppDelegate.swift in Sources */,
 				827EE3F625B6802D008A35BC /* CurrentWeather.swift in Sources */,
 				C79C8CF625ADDDF200EEE3F1 /* SceneDelegate.swift in Sources */,

--- a/WeatherForecast/WeatherForecast/Base.lproj/Main.storyboard
+++ b/WeatherForecast/WeatherForecast/Base.lproj/Main.storyboard
@@ -20,9 +20,25 @@
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YiX-ec-Y9X">
                                 <rect key="frame" x="173" y="341" width="94" height="40"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
+                                <state key="normal" title="현재 날씨"/>
                                 <connections>
-                                    <action selector="printWeather" destination="BYZ-38-t0r" eventType="touchUpInside" id="9bM-BG-3hf"/>
+                                    <action selector="printCurrentWeather" destination="BYZ-38-t0r" eventType="touchUpInside" id="Apl-ui-wLa"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0cs-ie-vEv">
+                                <rect key="frame" x="173" y="411" width="94" height="40"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="5일 예보"/>
+                                <connections>
+                                    <action selector="printForecastFiveDays" destination="BYZ-38-t0r" eventType="touchUpInside" id="bnW-Im-Vee"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2D3-de-1UJ">
+                                <rect key="frame" x="173" y="277" width="94" height="40"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="현재 주소"/>
+                                <connections>
+                                    <action selector="printCurrentAddress" destination="BYZ-38-t0r" eventType="touchUpInside" id="LRC-aH-Ryk"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/WeatherForecast/WeatherForecast/ForecastFiveDays.swift
+++ b/WeatherForecast/WeatherForecast/ForecastFiveDays.swift
@@ -11,7 +11,7 @@ struct ForecastFiveDays: Decodable {
     let numberOfTimestamps: Int
     let list: [ForecastList]
     
-    enum CodingKeys:String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case numberOfTimestamps = "cnt"
         case list
     }

--- a/WeatherForecast/WeatherForecast/Info.plist
+++ b/WeatherForecast/WeatherForecast/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>앱을 열때마다 위치정보 가져오기 허용</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/WeatherForecast/WeatherForecast/InitailValues.swift
+++ b/WeatherForecast/WeatherForecast/InitailValues.swift
@@ -1,0 +1,8 @@
+//
+//  InitailValues.swift
+//  WeatherForecast
+//
+//  Created by 김태형 on 2021/01/22.
+//
+
+import Foundation

--- a/WeatherForecast/WeatherForecast/InitailValues.swift
+++ b/WeatherForecast/WeatherForecast/InitailValues.swift
@@ -6,3 +6,10 @@
 //
 
 import Foundation
+
+enum InitialValue {
+    static let latitude = 0.0
+    static let longitude = 0.0
+    static let emptyString = ""
+    static let localIdentifier = "Ko-kr"
+}

--- a/WeatherForecast/WeatherForecast/URLManger.swift
+++ b/WeatherForecast/WeatherForecast/URLManger.swift
@@ -1,0 +1,42 @@
+//
+//  APIManger.swift
+//  WeatherForecast
+//
+//  Created by 김태형 on 2021/01/22.
+//
+
+import Foundation
+
+class URLManager {
+    static let common = URLManager()
+    private init() {}
+    
+    enum Mode {
+        case currentWeather
+        case forecastFiveDays
+        
+        var baseURL: String {
+            let mainURL = "https://api.openweathermap.org/data/2.5"
+            switch self {
+            case .currentWeather:
+                return "\(mainURL)/weather?"
+            default:
+                return "\(mainURL)/forecast?"
+            }
+        }
+    }
+    
+    func MakeURL(mode: Mode, latitude: Double, lontitude: Double) -> URL? {
+        let units = URLQueryItem(name: "units", value: "metric")
+        let myKey = URLQueryItem(name: "appid", value: "bdc8daed0ec51c18dfc0d8b9c84bb17c")
+        let latitude = URLQueryItem(name: "lat", value: String(latitude))
+        let lontitude = URLQueryItem(name: "lon", value: String(lontitude))
+        
+        guard var finalURL = URLComponents(string: mode.baseURL) else {
+            return nil
+        }
+        finalURL.queryItems = [latitude, lontitude, myKey, units]
+        
+        return finalURL.url
+    }
+}

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -5,24 +5,46 @@
 // 
 
 import UIKit
+import CoreLocation
 
-class ViewController: UIViewController {
-
-    var currentWeather: ForecastFiveDays?
+final class ViewController: UIViewController, CLLocationManagerDelegate {
+    
+    private var currentWeather: CurrentWeather?
+    private var forecastFiveDays: ForecastFiveDays?
     
     private func decodeCurrentWeaterFromAPI() {
         let session = URLSession(configuration: .default)
-        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/forecast?lat=35&lon=125&appid=4119f1d1ea30af76104279475caf11c7") else {
+        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/weather?lat=36&lon=128&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c") else {
             return
         }
-
+        
         let dataTask = session.dataTask(with: url) { data,_,error  in
             guard let data = data else {
                 return
             }
-
+            
             do {
-                self.currentWeather = try JSONDecoder().decode(ForecastFiveDays.self, from: data)
+                self.currentWeather = try JSONDecoder().decode(CurrentWeather.self, from: data)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        dataTask.resume()
+    }
+    
+    private func decodeForecastFiveDaysFromAPI() {
+        let session = URLSession(configuration: .default)
+        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/forecast?lat=36&lon=128&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c") else {
+            return
+        }
+        
+        let dataTask = session.dataTask(with: url) { data,_,error  in
+            guard let data = data else {
+                return
+            }
+            
+            do {
+                self.forecastFiveDays = try JSONDecoder().decode(ForecastFiveDays.self, from: data)
             } catch {
                 print(error.localizedDescription)
             }
@@ -34,12 +56,15 @@ class ViewController: UIViewController {
         dump(currentWeather)
     }
     
+    @IBAction func printForecastFiveDays() {
+        dump(forecastFiveDays)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         decodeCurrentWeaterFromAPI()
-
+        decodeForecastFiveDaysFromAPI()
     }
-
 }
 
 

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -95,7 +95,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     func convertToAddress(latitude: Double, longitude: Double) {
         let geoCoder: CLGeocoder = CLGeocoder()
         let coordinate: CLLocation = CLLocation(latitude: latitude, longitude: longitude)
-        let local: Locale = Locale(identifier: InitialValue.emptyString)
+        let local: Locale = Locale(identifier: InitialValue.localIdentifier)
         geoCoder.reverseGeocodeLocation(coordinate, preferredLocale: local) { place, _ in
             guard let address: [CLPlacemark] = place, let state = address.last?.administrativeArea, let city = address.first?.locality, let township = address.first?.subLocality else {
                 return

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -11,6 +11,9 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     
     private var currentWeather: CurrentWeather?
     private var forecastFiveDays: ForecastFiveDays?
+    private var locationManager: CLLocationManager!
+    private var latitude: Double?
+    private var longitude: Double?
     
     private func decodeCurrentWeaterFromAPI() {
         let session = URLSession(configuration: .default)
@@ -62,9 +65,30 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        locationManager = CLLocationManager()
+        locationManager.delegate = self
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.requestLocation()
+        
         decodeCurrentWeaterFromAPI()
         decodeForecastFiveDaysFromAPI()
     }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let coordinate = locationManager.location?.coordinate else {
+            return
+        }
+        latitude = coordinate.latitude
+        longitude = coordinate.longitude
+        
+        print(latitude, longitude)
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        //show error
+    }
+    
 }
 
 

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -32,7 +32,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     
     private func decodeCurrentWeaterFromAPI(latitude: Double, longitude: Double) {
         let session = URLSession(configuration: .default)
-        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/weather?lat=\(latitude)&lon=\(longitude)&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c&units=metric") else {
+        guard let url:URL = URLManager.common.MakeURL(mode: .currentWeather, latitude: latitude, lontitude: longitude) else {
             return
         }
         let dataTask = session.dataTask(with: url) { data,_,error  in
@@ -50,7 +50,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
 
     private func decodeForecastFiveDaysFromAPI(latitude: Double, longitude: Double) {
         let session = URLSession(configuration: .default)
-        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/forecast?lat=\(latitude)&lon=\(longitude)&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c&units=metric") else {
+        guard let url:URL = URLManager.common.MakeURL(mode: .forecastFiveDays, latitude: latitude, lontitude: longitude) else {
             return
         }
         let dataTask = session.dataTask(with: url) { data,_,error  in

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -16,9 +16,14 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     private var latitude: Double = 0.0
     private var longitude: Double = 0.0
     
-    private func decodeCurrentWeaterFromAPI() {
+    private func setUpAPI(latitude: Double, longitude: Double) {
+        decodeCurrentWeaterFromAPI(latitude: latitude, longitude: longitude)
+        decodeForecastFiveDaysFromAPI(latitude: latitude, longitude: longitude)
+    }
+    
+    private func decodeCurrentWeaterFromAPI(latitude: Double, longitude: Double) {
         let session = URLSession(configuration: .default)
-        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/weather?lat=36.12960776717609&lon=128.31720057056822&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c&units=metric") else {
+        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/weather?lat=\(latitude)&lon=\(longitude)&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c&units=metric") else {
             return
         }
         let dataTask = session.dataTask(with: url) { data,_,error  in
@@ -34,9 +39,9 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
         dataTask.resume()
     }
 
-    private func decodeForecastFiveDaysFromAPI() {
+    private func decodeForecastFiveDaysFromAPI(latitude: Double, longitude: Double) {
         let session = URLSession(configuration: .default)
-        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/forecast?lat=36.12960776717609&lon=128.31720057056822&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c&units=metric") else {
+        guard let url:URL = URL(string: "https://api.openweathermap.org/data/2.5/forecast?lat=\(latitude)&lon=\(longitude)&appid=bdc8daed0ec51c18dfc0d8b9c84bb17c&units=metric") else {
             return
         }
         let dataTask = session.dataTask(with: url) { data,_,error  in
@@ -52,12 +57,16 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
         dataTask.resume()
     }
     
-    @IBAction func printWeather() {
+    @IBAction func printCurrentWeather() {
         dump(currentWeather)
     }
     
     @IBAction func printForecastFiveDays() {
         dump(forecastFiveDays)
+    }
+    
+    @IBAction func printCurrentAddress() {
+        print(currentAddress)
     }
     
     override func viewDidLoad() {
@@ -67,9 +76,6 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
         locationManager.delegate = self
         locationManager.requestWhenInUseAuthorization()
         locationManager.requestLocation()
-        
-        decodeCurrentWeaterFromAPI()
-        decodeForecastFiveDaysFromAPI()
     }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
@@ -78,11 +84,12 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
         }
         latitude = coordinate.latitude
         longitude = coordinate.longitude
+        setUpAPI(latitude: latitude, longitude: longitude)
         convertToAddress(latitude: latitude, longitude: longitude)
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        //show error
+        print(error.localizedDescription)
     }
     
     func convertToAddress(latitude: Double, longitude: Double) {

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -12,9 +12,18 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     private var currentWeather: CurrentWeather?
     private var forecastFiveDays: ForecastFiveDays?
     private var locationManager: CLLocationManager!
-    private var currentAddress: String = ""
-    private var latitude: Double = 0.0
-    private var longitude: Double = 0.0
+    private var currentAddress: String = InitialValue.emptyString
+    private var latitude: Double = InitialValue.latitude
+    private var longitude: Double = InitialValue.longitude
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        locationManager = CLLocationManager()
+        locationManager.delegate = self
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.requestLocation()
+    }
     
     private func setUpAPI(latitude: Double, longitude: Double) {
         decodeCurrentWeaterFromAPI(latitude: latitude, longitude: longitude)
@@ -69,15 +78,6 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
         print(currentAddress)
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        locationManager = CLLocationManager()
-        locationManager.delegate = self
-        locationManager.requestWhenInUseAuthorization()
-        locationManager.requestLocation()
-    }
-    
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let coordinate = locationManager.location?.coordinate else {
             return
@@ -95,7 +95,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate {
     func convertToAddress(latitude: Double, longitude: Double) {
         let geoCoder: CLGeocoder = CLGeocoder()
         let coordinate: CLLocation = CLLocation(latitude: latitude, longitude: longitude)
-        let local: Locale = Locale(identifier: "Ko-kr")
+        let local: Locale = Locale(identifier: InitialValue.emptyString)
         geoCoder.reverseGeocodeLocation(coordinate, preferredLocale: local) { place, _ in
             guard let address: [CLPlacemark] = place, let state = address.last?.administrativeArea, let city = address.first?.locality, let township = address.first?.subLocality else {
                 return


### PR DESCRIPTION
@O-O-wl 🦉 🙌 (부.하!)
붱이 안녕하세요 ! 두번째 스텝 첫 PR 입니다.🔥
시간이 너무 훅훅 지나가네요.. 벌써 금요일이라니 이번주 마무리 잘하세요 ! 😄

저번 PR에서 API를 통해 JSON 이 제대로 받아지는지에만 중점을 두다보니 네이밍을 신경쓰지 못했어요.. 이번에는 수정을 했습니다 ! 

1.  ARC를 공부해보셨으니 혹시 여기서 strong self를 물고있으면 어떤 부작용이 있을 수 있을까요?

 > 질문하신 의도에 맞게 제가 답을 하는게 맞는지 모르겠지만, strong을 사용하게 되면 RC가 증가 하게되는데 이때, strong self를 물고 있고 다른 참조타입을 가지는 class, closure가 서로를 바라본다면 서로 해제되기를 기다리면서 Strong Reference Cycle 문제가 생길 수 있는것을 확인하였습니다. 해결 방법으로는 weak self같은 방법들을 보았는데 그 부분은 조금 더 공부를 해야할 것 같아요. 해당 내용은 [Apple 공식문서 ARC](https://docs.swift.org/swift-book/LanguageGuide/AutomaticReferenceCounting.html#ID52)를 참고하였습니다.

2.  현재 위치의 경도와 위도를 구하기 위해서 CLLocationManager를 사용하였습니다. 현재 위치를 받아오기 위해 Info.plist 에서 권한을 얻어오게 하였고, requestLocation을 통해 위치정보를 요청하고 didUpdateLocations에서 위도와 경도를 받아 API 와 CLGoecoder로 넘겨주었습니다. 

3. 현재 주소를 구하기 위해서 CLGeocoder의 reverseGeocodeLocation 메서드를 사용하였습니다. 겪었던 문제점은 지역마다 CLPlacemark에 담겨 있는 정보가 달라 수도권이 아닌 지방에서는 Thoroughfare와 같은 정보들은 없었습니다. 😭
도 = administrativeArea, 시 = locality, 동 = subLocality를 통해 정보를 가지고 왔습니다. 
위 내용은 [Apple 공식문서 CLPlacemark](https://developer.apple.com/documentation/corelocation/clplacemark)를 참고하였습니다.
현재 주소를 한글로 출력하기 위해서 [reverseGeocodeLocation](https://developer.apple.com/documentation/corelocation/clgeocoder/2908779-reversegeocodelocation) 의 prefererdLocale의 값을 한국으로 지정해 주었습니다.

4. 마지막으로 API 의 URL주소를 만들어주는 기능을 구현해 보았습니다.
[URLComponent](https://developer.apple.com/documentation/foundation/urlcomponents) 와 [URLqueryItems](https://developer.apple.com/documentation/foundation/urlqueryitem) 참고하고 예제로 [zedd님의 URLComponets 포스팅](https://zeddios.tistory.com/1103)을 참고하였습니다.

추가 사항 ) 
API 통신, 위치정보 권한 관련 에러 핸들링은 PR보내고.. 진행하도록 하겠습니다 ! 🚀  