### PR TITLE
날씨 정보 [Step3] shapiro, coden

### DIFF
--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F14EBB5271478A80090C854 /* MainWeatherHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14EBB4271478A80090C854 /* MainWeatherHeaderView.swift */; };
 		3F444DBB2702E61600E60AA4 /* Wind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F444DBA2702E61600E60AA4 /* Wind.swift */; };
 		3F444DC32702EA6C00E60AA4 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F444DC22702EA6C00E60AA4 /* System.swift */; };
 		3F444DCB2702EEFC00E60AA4 /* Snow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F444DCA2702EEFC00E60AA4 /* Snow.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3F14EBB4271478A80090C854 /* MainWeatherHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWeatherHeaderView.swift; sourceTree = "<group>"; };
 		3F444DBA2702E61600E60AA4 /* Wind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wind.swift; sourceTree = "<group>"; };
 		3F444DC22702EA6C00E60AA4 /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		3F444DCA2702EEFC00E60AA4 /* Snow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snow.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				C96F2ED927144F1E00004338 /* MainWeatherTableViewCell.swift */,
+				3F14EBB4271478A80090C854 /* MainWeatherHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -371,6 +374,7 @@
 				C91EF6A62702FC290013E3D6 /* FiveDayWeatherForecast.swift in Sources */,
 				C91EF6AD270311600013E3D6 /* APIable.swift in Sources */,
 				3F444DCB2702EEFC00E60AA4 /* Snow.swift in Sources */,
+				3F14EBB5271478A80090C854 /* MainWeatherHeaderView.swift in Sources */,
 				C91EF6A42702EF880013E3D6 /* City.swift in Sources */,
 				C91EF69E2702E7430013E3D6 /* Clouds.swift in Sources */,
 				C96F2EDC2714632800004338 /* MainWeatherTableViewDataSource.swift in Sources */,

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		C91EF6AD270311600013E3D6 /* APIable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91EF6AC270311600013E3D6 /* APIable.swift */; };
 		C91EF6B127035D330013E3D6 /* WeatherAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91EF6B027035D330013E3D6 /* WeatherAPI.swift */; };
 		C91EF6B62706E5250013E3D6 /* ParsingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91EF6B52706E5250013E3D6 /* ParsingManager.swift */; };
+		C96F2EDA27144F1E00004338 /* MainWeatherTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96F2ED927144F1E00004338 /* MainWeatherTableViewCell.swift */; };
 		C9D4DB91270C460300EAF3A5 /* AddressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D4DB90270C460300EAF3A5 /* AddressManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -83,6 +84,7 @@
 		C91EF6B027035D330013E3D6 /* WeatherAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPI.swift; sourceTree = "<group>"; };
 		C91EF6B22706D9700013E3D6 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		C91EF6B52706E5250013E3D6 /* ParsingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingManager.swift; sourceTree = "<group>"; };
+		C96F2ED927144F1E00004338 /* MainWeatherTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWeatherTableViewCell.swift; sourceTree = "<group>"; };
 		C9D4DB90270C460300EAF3A5 /* AddressManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -153,6 +155,7 @@
 		C79C8CF225ADDDF200EEE3F1 /* WeatherForecast */ = {
 			isa = PBXGroup;
 			children = (
+				C96F2ED827144EF500004338 /* View */,
 				C9D4DB8D270C28BE00EAF3A5 /* Controller */,
 				C91EF6982702DB640013E3D6 /* Model */,
 				C79C8CF325ADDDF200EEE3F1 /* AppDelegate.swift */,
@@ -211,6 +214,14 @@
 				C9D4DB90270C460300EAF3A5 /* AddressManager.swift */,
 			);
 			path = Manager;
+			sourceTree = "<group>";
+		};
+		C96F2ED827144EF500004338 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				C96F2ED927144F1E00004338 /* MainWeatherTableViewCell.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		C9D4DB8D270C28BE00EAF3A5 /* Controller */ = {
@@ -351,6 +362,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C96F2EDA27144F1E00004338 /* MainWeatherTableViewCell.swift in Sources */,
 				3F756ADA2706FB340091A124 /* NetworkManager.swift in Sources */,
 				C91EF69C2702E0290013E3D6 /* MainWeatherInformation.swift in Sources */,
 				C91EF6A62702FC290013E3D6 /* FiveDayWeatherForecast.swift in Sources */,

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		C91EF6B127035D330013E3D6 /* WeatherAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91EF6B027035D330013E3D6 /* WeatherAPI.swift */; };
 		C91EF6B62706E5250013E3D6 /* ParsingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91EF6B52706E5250013E3D6 /* ParsingManager.swift */; };
 		C96F2EDA27144F1E00004338 /* MainWeatherTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96F2ED927144F1E00004338 /* MainWeatherTableViewCell.swift */; };
+		C96F2EDC2714632800004338 /* MainWeatherTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96F2EDB2714632800004338 /* MainWeatherTableViewDataSource.swift */; };
 		C9D4DB91270C460300EAF3A5 /* AddressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D4DB90270C460300EAF3A5 /* AddressManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -85,6 +86,7 @@
 		C91EF6B22706D9700013E3D6 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		C91EF6B52706E5250013E3D6 /* ParsingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingManager.swift; sourceTree = "<group>"; };
 		C96F2ED927144F1E00004338 /* MainWeatherTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWeatherTableViewCell.swift; sourceTree = "<group>"; };
+		C96F2EDB2714632800004338 /* MainWeatherTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWeatherTableViewDataSource.swift; sourceTree = "<group>"; };
 		C9D4DB90270C460300EAF3A5 /* AddressManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -228,6 +230,7 @@
 			isa = PBXGroup;
 			children = (
 				C79C8CF725ADDDF200EEE3F1 /* MainWeatherViewController.swift */,
+				C96F2EDB2714632800004338 /* MainWeatherTableViewDataSource.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				3F444DCB2702EEFC00E60AA4 /* Snow.swift in Sources */,
 				C91EF6A42702EF880013E3D6 /* City.swift in Sources */,
 				C91EF69E2702E7430013E3D6 /* Clouds.swift in Sources */,
+				C96F2EDC2714632800004338 /* MainWeatherTableViewDataSource.swift in Sources */,
 				C79C8CF825ADDDF200EEE3F1 /* MainWeatherViewController.swift in Sources */,
 				C91EF6B127035D330013E3D6 /* WeatherAPI.swift in Sources */,
 				C9D4DB91270C460300EAF3A5 /* AddressManager.swift in Sources */,

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
@@ -47,7 +47,6 @@ extension MainWeatherTableViewDataSource: UITableViewDataSource {
                 }
             }
         }
-        
         return cell
     }
     

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
@@ -8,8 +8,15 @@
 import UIKit
 
 final class MainWeatherTableViewDataSource: NSObject {
-    private var fiveDayWeatherList: [WeatherForOneDay] = []
-    
+    private var _fiveDayWeatherList: [WeatherForOneDay] = []
+    var fiveDayWeatherList: [WeatherForOneDay] {
+        set {
+            _fiveDayWeatherList = newValue
+        }
+        get {
+            return _fiveDayWeatherList
+        }
+    }
 }
 
 extension MainWeatherTableViewDataSource: UITableViewDataSource {

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
@@ -28,8 +28,25 @@ extension MainWeatherTableViewDataSource: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MainWeatherTableViewCell.identifier, for: indexPath) as? MainWeatherTableViewCell else {
             return UITableViewCell()
         }
+        cell.resetAllContents()
         let weather = fiveDayWeatherList[indexPath.row]
         cell.configure(data: weather)
+        cell.iconId = weather.weatherConditionCodes?.last?.iconId
+        if let imageId = cell.iconId {
+            NetworkManager.imageRequest(using: imageId) { result in
+                guard cell.iconId == imageId else {
+                    return
+                }
+                DispatchQueue.main.async {
+                    switch result {
+                    case .failure(_):
+                        break
+                    case .success(let image):
+                        cell.configure(image: image)
+                    }
+                }
+            }
+        }
         
         return cell
     }

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherTableViewDataSource.swift
@@ -1,0 +1,31 @@
+//
+//  MainWeatherTableViewDataSource.swift
+//  WeatherForecast
+//
+//  Created by JINHONG AN on 2021/10/11.
+//
+
+import UIKit
+
+final class MainWeatherTableViewDataSource: NSObject {
+    private var fiveDayWeatherList: [WeatherForOneDay] = []
+    
+}
+
+extension MainWeatherTableViewDataSource: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return fiveDayWeatherList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: MainWeatherTableViewCell.identifier, for: indexPath) as? MainWeatherTableViewCell else {
+            return UITableViewCell()
+        }
+        let weather = fiveDayWeatherList[indexPath.row]
+        cell.configure(data: weather)
+        
+        return cell
+    }
+    
+    
+}

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -130,6 +130,7 @@ extension MainWeatherViewController {
 extension MainWeatherViewController {
     private func setUpTableView() {
         view.addSubview(tableView)
+        tableView.register(MainWeatherTableViewCell.self, forCellReuseIdentifier: MainWeatherTableViewCell.identifier)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         
         let safeArea = view.safeAreaLayoutGuide

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -16,6 +16,7 @@ final class MainWeatherViewController: UIViewController {
     private let prepareInformationDispatchGroup = DispatchGroup()
     private var updateWorkItem: DispatchWorkItem?
     private let tableView = UITableView()
+    private let tableViewDataSource = MainWeatherTableViewDataSource()
     
     //MARK: Lifecycle
     override func viewDidLoad() {
@@ -138,6 +139,8 @@ extension MainWeatherViewController {
         tableView.leftAnchor.constraint(equalTo: safeArea.leftAnchor).isActive = true
         tableView.rightAnchor.constraint(equalTo: safeArea.rightAnchor).isActive = true
         tableView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor).isActive = true
+        
+        tableView.dataSource = tableViewDataSource
     }
     
     private func updateUserAddressLabel() {

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -157,6 +157,18 @@ extension MainWeatherViewController {
         guard let newInformation = newInformation else {
             return
         }
+        if let imageId = newInformation.weatherConditionCodes?.last?.iconId {
+            NetworkManager.imageRequest(using: imageId) { [self] result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .failure(_):
+                        break
+                    case .success(let image):
+                        headerView.configure(image: image)
+                    }
+                }
+            }
+        }
         headerView.configure(weatherData: newInformation)
         sizeHeaderViewHeightToFit()
     }

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -16,6 +16,7 @@ final class MainWeatherViewController: UIViewController {
     private let prepareInformationDispatchGroup = DispatchGroup()
     private var updateWorkItem: DispatchWorkItem?
     private let tableView = UITableView()
+    private let headerView = MainWeatherHeaderView()
     private let tableViewDataSource = MainWeatherTableViewDataSource()
     
     //MARK: Lifecycle
@@ -141,6 +142,7 @@ extension MainWeatherViewController {
         tableView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor).isActive = true
         
         tableView.dataSource = tableViewDataSource
+        tableView.tableHeaderView = headerView
     }
     
     private func updateUserAddressLabel() {
@@ -148,7 +150,17 @@ extension MainWeatherViewController {
     }
     
     private func updateHeadView() {
-        
+
+    }
+    
+    private func sizeHeaderViewHeightToFit() {
+        guard let headerView = tableView.tableHeaderView else {
+            return
+        }
+        let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        var frame = headerView.frame
+        frame.size.height = height
+        headerView.frame = frame
     }
     
     private func updateTableView(to newInformation: [WeatherForOneDay]?) {

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -63,7 +63,7 @@ extension MainWeatherViewController: CLLocationManagerDelegate {
                 }
                 if self?.fiveDayWeatherForecast != weatherForFiveDay {
                     self?.fiveDayWeatherForecast = weatherForFiveDay
-                    self?.updateTableView()
+                    self?.updateTableView(to: weatherForFiveDay?.weatherForFiveDays)
                 }
             }
         })
@@ -151,7 +151,11 @@ extension MainWeatherViewController {
         
     }
     
-    private func updateTableView() {
-        
+    private func updateTableView(to newInformation: [WeatherForOneDay]?) {
+        guard let newInformation = newInformation else {
+            return
+        }
+        tableViewDataSource.fiveDayWeatherList = newInformation
+        tableView.reloadData()
     }
 }

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -26,6 +26,7 @@ final class MainWeatherViewController: UIViewController {
         guard CLLocationManager.significantLocationChangeMonitoringAvailable() else { return }
         locationManager.startMonitoringSignificantLocationChanges()
         setUpTableView()
+        setUpRefreshControl()
     }
 }
 
@@ -66,6 +67,7 @@ extension MainWeatherViewController: CLLocationManagerDelegate {
                     self?.fiveDayWeatherForecast = weatherForFiveDay
                     self?.updateTableView(to: weatherForFiveDay?.weatherForFiveDays)
                 }
+                self?.tableView.refreshControl?.endRefreshing()
             }
         })
         if let updateWorkItem = updateWorkItem {
@@ -145,6 +147,11 @@ extension MainWeatherViewController {
         tableView.tableHeaderView = headerView
     }
     
+    private func setUpRefreshControl() {
+        tableView.refreshControl = UIRefreshControl()
+        tableView.refreshControl?.addTarget(self, action: #selector(loadNewData), for: .valueChanged)
+    }
+    
     private func updateUserAddressLabel(to newInformation: String?) {
         guard let newInformation = newInformation else {
             return
@@ -189,5 +196,13 @@ extension MainWeatherViewController {
         }
         tableViewDataSource.fiveDayWeatherList = newInformation
         tableView.reloadData()
+    }
+    
+    @objc private func loadNewData() {
+        guard let lastLocation = locationManager.location else {
+            tableView.refreshControl?.endRefreshing()
+            return
+        }
+        locationManager(locationManager, didUpdateLocations: [lastLocation])
     }
 }

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -22,11 +22,18 @@ final class MainWeatherViewController: UIViewController {
     //MARK: Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setUpLocationManager()
+        setUpTableView()
+        setUpRefreshControl()
+    }
+}
+
+//MARK:- LocationManager
+extension MainWeatherViewController {
+    private func setUpLocationManager() {
         locationManager.delegate = self
         guard CLLocationManager.significantLocationChangeMonitoringAvailable() else { return }
         locationManager.startMonitoringSignificantLocationChanges()
-        setUpTableView()
-        setUpRefreshControl()
     }
 }
 

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -15,6 +15,7 @@ final class MainWeatherViewController: UIViewController {
     private var fiveDayWeatherForecast: FiveDayWeatherForecast?
     private let prepareInformationDispatchGroup = DispatchGroup()
     private var updateWorkItem: DispatchWorkItem?
+    private let tableView = UITableView()
     
     //MARK: Lifecycle
     override func viewDidLoad() {
@@ -22,6 +23,7 @@ final class MainWeatherViewController: UIViewController {
         locationManager.delegate = self
         guard CLLocationManager.significantLocationChangeMonitoringAvailable() else { return }
         locationManager.startMonitoringSignificantLocationChanges()
+        setUpTableView()
     }
 }
 
@@ -126,6 +128,17 @@ extension MainWeatherViewController {
 
 //MARK:- UI
 extension MainWeatherViewController {
+    private func setUpTableView() {
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let safeArea = view.safeAreaLayoutGuide
+        tableView.topAnchor.constraint(equalTo: safeArea.topAnchor).isActive = true
+        tableView.leftAnchor.constraint(equalTo: safeArea.leftAnchor).isActive = true
+        tableView.rightAnchor.constraint(equalTo: safeArea.rightAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor).isActive = true
+    }
+    
     private func updateUserAddressLabel() {
 
     }

--- a/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
+++ b/WeatherForecast/WeatherForecast/Controller/MainWeatherViewController.swift
@@ -56,11 +56,11 @@ extension MainWeatherViewController: CLLocationManagerDelegate {
             self?.prepareWeatherInformation(with: lastLocation) { userAddress, weatherForOneDay, weatherForFiveDay in
                 if self?.userAddress != userAddress {
                     self?.userAddress = userAddress
-                    self?.updateUserAddressLabel()
+                    self?.updateUserAddressLabel(to: userAddress)
                 }
                 if self?.weatherForOneDay != weatherForOneDay {
                     self?.weatherForOneDay = weatherForOneDay
-                    self?.updateHeadView()
+                    self?.updateHeadView(to: weatherForOneDay)
                 }
                 if self?.fiveDayWeatherForecast != weatherForFiveDay {
                     self?.fiveDayWeatherForecast = weatherForFiveDay
@@ -145,12 +145,20 @@ extension MainWeatherViewController {
         tableView.tableHeaderView = headerView
     }
     
-    private func updateUserAddressLabel() {
-
+    private func updateUserAddressLabel(to newInformation: String?) {
+        guard let newInformation = newInformation else {
+            return
+        }
+        headerView.configure(addressData: newInformation)
+        sizeHeaderViewHeightToFit()
     }
     
-    private func updateHeadView() {
-
+    private func updateHeadView(to newInformation: WeatherForOneDay?) {
+        guard let newInformation = newInformation else {
+            return
+        }
+        headerView.configure(weatherData: newInformation)
+        sizeHeaderViewHeightToFit()
     }
     
     private func sizeHeaderViewHeightToFit() {

--- a/WeatherForecast/WeatherForecast/Model/Manager/AddressManager.swift
+++ b/WeatherForecast/WeatherForecast/Model/Manager/AddressManager.swift
@@ -17,7 +17,7 @@ enum AddressTranslationError: Error, LocalizedError {
         case .failedToGetAddress:
             return "주소값을 얻어오는데에 실패하였습니다."
         case .invalidAddress:
-            return "도로명 주소가 존재하지 않습니다."
+            return "유효한 주소가 존재하지 않습니다."
         }
     }
 }
@@ -32,10 +32,10 @@ struct AddressManager {
             guard let placeMarks = placeMarks, let address = placeMarks.last else {
                 return completionHandler(.failure(AddressTranslationError.failedToGetAddress))
             }
-            guard let adminstrativeArea = address.administrativeArea, let roadName = address.thoroughfare else {
+            guard let adminstrativeArea = address.administrativeArea, let locality = address.locality, let thoroughfare = address.thoroughfare else {
                 return completionHandler(.failure(AddressTranslationError.invalidAddress))
             }
-            let userAddress = "\(adminstrativeArea) \(roadName)"
+            let userAddress = "\(adminstrativeArea) \(locality) \(thoroughfare)"
             completionHandler(.success(userAddress))
         }
     }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -107,4 +107,8 @@ class MainWeatherHeaderView: UIView {
             currentTamperatureLabel.text = (((currentKelvinTemperature + absoluteZero) * 10).rounded(.toNearestOrAwayFromZero) / 10).description
         }
     }
+    
+    func configure(image: UIImage) {
+        weatherIconImageView.image = image
+    }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -1,0 +1,68 @@
+//
+//  MainWeatherHeaderView.swift
+//  WeatherForecast
+//
+//  Created by Kim Do hyung on 2021/10/11.
+//
+
+import UIKit
+
+class MainWeatherHeaderView: UIView {
+    private let weatherIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor).isActive = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return imageView
+    }()
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .leading
+        
+        return stackView
+    }()
+    private let temperatureStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .equalSpacing
+        stackView.alignment = .center
+        
+        return stackView
+    }()
+    private let addressLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .callout)
+        
+        return label
+    }()
+    private let lowestTemperatureLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .callout)
+        
+        return label
+    }()
+    private let highestTemperatureLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .callout)
+        
+        return label
+    }()
+    private let currentTamperatureLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .title2)
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -30,6 +30,7 @@ class MainWeatherHeaderView: UIView {
         stackView.axis = .horizontal
         stackView.distribution = .equalSpacing
         stackView.alignment = .center
+        stackView.spacing = UIStackView.spacingUseSystem
         
         return stackView
     }()
@@ -90,10 +91,20 @@ class MainWeatherHeaderView: UIView {
     }
     
     func configure(addressData: String) {
-        
+        addressLabel.text = addressData
     }
     
     func configure(weatherData: WeatherForOneDay) {
-        
+        let absoluteZero = -273.15
+
+        if let highestKelvinTemperature = weatherData.mainWeatherInfomation?.maximumTemperature {
+            highestTemperatureLabel.text = "최고 " + (((highestKelvinTemperature + absoluteZero) * 10).rounded(.toNearestOrAwayFromZero) / 10).description
+        }
+        if let lowestKelvinTemperature = weatherData.mainWeatherInfomation?.minimumTemperature {
+            lowestTemperatureLabel.text = "최저 " + (((lowestKelvinTemperature + absoluteZero) * 10).rounded(.toNearestOrAwayFromZero) / 10).description
+        }
+        if let currentKelvinTemperature = weatherData.mainWeatherInfomation?.temperature {
+            currentTamperatureLabel.text = (((currentKelvinTemperature + absoluteZero) * 10).rounded(.toNearestOrAwayFromZero) / 10).description
+        }
     }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -79,12 +79,13 @@ class MainWeatherHeaderView: UIView {
         stackView.addArrangedSubview(temperatureStackView)
         stackView.addArrangedSubview(currentTamperatureLabel)
         
-        weatherIconImageView.topAnchor.constraint(equalTo: topAnchor, constant: margin).isActive = true
         weatherIconImageView.leftAnchor.constraint(equalTo: leftAnchor, constant: margin).isActive = true
-        weatherIconImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
+        weatherIconImageView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.2).isActive = true
+        weatherIconImageView.heightAnchor.constraint(equalTo: weatherIconImageView.widthAnchor).isActive = true
+        weatherIconImageView.centerYAnchor.constraint(equalTo: stackView.centerYAnchor).isActive = true
         
         stackView.leadingAnchor.constraint(equalTo: weatherIconImageView.trailingAnchor, constant: margin).isActive = true
-        
+
         stackView.topAnchor.constraint(equalTo: topAnchor, constant: margin).isActive = true
         stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
         stackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -88,4 +88,12 @@ class MainWeatherHeaderView: UIView {
         stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
         stackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
     }
+    
+    func configure(addressData: String) {
+        
+    }
+    
+    func configure(weatherData: WeatherForOneDay) {
+        
+    }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -83,6 +83,7 @@ class MainWeatherHeaderView: UIView {
         weatherIconImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
         
         stackView.leadingAnchor.constraint(equalTo: weatherIconImageView.trailingAnchor, constant: margin).isActive = true
+        
         stackView.topAnchor.constraint(equalTo: topAnchor, constant: margin).isActive = true
         stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
         stackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true

--- a/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherHeaderView.swift
@@ -60,9 +60,31 @@ class MainWeatherHeaderView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setUpUI()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+    
+    private func setUpUI() {
+        addSubview(weatherIconImageView)
+        addSubview(stackView)
+        
+        let margin = CGFloat(10)
+        temperatureStackView.addArrangedSubview(lowestTemperatureLabel)
+        temperatureStackView.addArrangedSubview(highestTemperatureLabel)
+        stackView.addArrangedSubview(addressLabel)
+        stackView.addArrangedSubview(temperatureStackView)
+        stackView.addArrangedSubview(currentTamperatureLabel)
+        
+        weatherIconImageView.topAnchor.constraint(equalTo: topAnchor, constant: margin).isActive = true
+        weatherIconImageView.leftAnchor.constraint(equalTo: leftAnchor, constant: margin).isActive = true
+        weatherIconImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
+        
+        stackView.leadingAnchor.constraint(equalTo: weatherIconImageView.trailingAnchor, constant: margin).isActive = true
+        stackView.topAnchor.constraint(equalTo: topAnchor, constant: margin).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -margin).isActive = true
+        stackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
     }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class MainWeatherTableViewCell: UITableViewCell {
     static let identifier = "MainWeatherTableViewCell"
+    var iconId: String?
     
     private let stackView: UIStackView = {
         let stackView = UIStackView()
@@ -79,5 +80,17 @@ final class MainWeatherTableViewCell: UITableViewCell {
             temperatureLabel.text = (((kelvinTemperature + absoluteZero) * 10).rounded(.toNearestOrAwayFromZero) / 10).description
         }
         
+    }
+    
+    func configure(image: UIImage) {
+        if weatherIconImageView.image == nil {
+            weatherIconImageView.image = image
+        }
+    }
+    
+    func resetAllContents() {
+        weatherIconImageView.image = nil
+        dateLabel.text = nil
+        temperatureLabel.text = nil
     }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -37,6 +37,7 @@ final class MainWeatherTableViewCell: UITableViewCell {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor).isActive = true
         
         return imageView
     }()
@@ -55,13 +56,28 @@ final class MainWeatherTableViewCell: UITableViewCell {
         stackView.addArrangedSubview(temperatureLabel)
         stackView.addArrangedSubview(weatherIconImageView)
         contentView.addSubview(stackView)
-        stackView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-        stackView.leftAnchor.constraint(equalTo: contentView.leftAnchor).isActive = true
-        stackView.rightAnchor.constraint(equalTo: contentView.rightAnchor).isActive = true
-        stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        
+        let margin = CGFloat(8)
+        stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: margin).isActive = true
+        stackView.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: margin).isActive = true
+        stackView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -margin).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -margin).isActive = true
     }
     
     func configure(data: WeatherForOneDay) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        
+        if let forecastedDate = data.timeOfDataForecasted, let date = dateFormatter.date(from: forecastedDate) {
+            dateFormatter.locale = .current
+            dateFormatter.setLocalizedDateFormatFromTemplate("MMMMdEHH")
+            dateLabel.text = dateFormatter.string(from: date)
+        }
+        
+        if let kelvinTemperature = data.mainWeatherInfomation?.temperature {
+            let absoluteZero = -273.15
+            temperatureLabel.text = (((kelvinTemperature + absoluteZero) * 10).rounded(.toNearestOrAwayFromZero) / 10).description
+        }
         
     }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -1,0 +1,42 @@
+//
+//  MainWeatherTableViewCell.swift
+//  WeatherForecast
+//
+//  Created by JINHONG AN on 2021/10/11.
+//
+
+import UIKit
+
+final class MainWeatherTableViewCell: UITableViewCell {
+    static let identifier = "MainWeatherTableViewCell"
+    private var dateLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    private var temperatureLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    private var weatherIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        
+        return imageView
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -71,8 +71,8 @@ final class MainWeatherTableViewCell: UITableViewCell {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         
-        if let forecastedDate = data.timeOfDataForecasted, let date = dateFormatter.date(from: forecastedDate) {
-            dateFormatter.locale = .current
+        if let forecastedDate = data.timeOfDataForecasted, let date = dateFormatter.date(from: forecastedDate), let preferredLanguage = Locale.preferredLanguages.first {
+            dateFormatter.locale = Locale(identifier: preferredLanguage)
             dateFormatter.setLocalizedDateFormatFromTemplate("MMMMdEHH")
             dateLabel.text = dateFormatter.string(from: date)
         }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -43,10 +43,25 @@ final class MainWeatherTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpUI()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
     
+    private func setUpUI() {
+        stackView.addArrangedSubview(dateLabel)
+        stackView.addArrangedSubview(temperatureLabel)
+        stackView.addArrangedSubview(weatherIconImageView)
+        contentView.addSubview(stackView)
+        stackView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        stackView.leftAnchor.constraint(equalTo: contentView.leftAnchor).isActive = true
+        stackView.rightAnchor.constraint(equalTo: contentView.rightAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+    }
+    
+    func configure(data: WeatherForOneDay) {
+        
+    }
 }

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -38,7 +38,6 @@ final class MainWeatherTableViewCell: UITableViewCell {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor).isActive = true
         
         return imageView
     }()
@@ -63,6 +62,9 @@ final class MainWeatherTableViewCell: UITableViewCell {
         stackView.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: margin).isActive = true
         stackView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -margin).isActive = true
         stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -margin).isActive = true
+        
+        weatherIconImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1).isActive = true
+        weatherIconImageView.heightAnchor.constraint(equalTo: weatherIconImageView.widthAnchor).isActive = true
     }
     
     func configure(data: WeatherForOneDay) {

--- a/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/View/MainWeatherTableViewCell.swift
@@ -9,24 +9,34 @@ import UIKit
 
 final class MainWeatherTableViewCell: UITableViewCell {
     static let identifier = "MainWeatherTableViewCell"
-    private var dateLabel: UILabel = {
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        
+        return stackView
+    }()
+    private let dateLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         
         return label
     }()
-    private var temperatureLabel: UILabel = {
+    private let temperatureLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    
         return label
     }()
-    private var weatherIconImageView: UIImageView = {
+    private let weatherIconImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
+        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         return imageView
     }()


### PR DESCRIPTION
@YebinKim 
안녕하세요 비비~! [STEP3]를 후딱 만들어서 PR을 날려봅니다! ㅎㅎ 
사실 이번에는 해결하지 못한 점들도 조금 있고 해서 여쭤볼게 많습니다..! 
이번에도 잘 부탁드립니다! 🙏
&nbsp;   
## 구현내용
1. TableView의 헤더뷰 UI 구현
헤더뷰에 들어갈 뷰를 커스텀으로 만들어서 붙이는 방식으로 구현하였습니다!

2. TableView CustomCell
커스텀 셀을 코드로만 구성하여 만들었습니다.

3. RefreshControl
사용자 상호작용이 일어났을 때 `CLLocationManagerDelegate`의 `locationManager(_:didUpdateLocations:)`를 직접 호출하는 방식으로 구현하였습니다.

4. 셀 이미지 지연로딩 문제
각각의 셀에 아이콘 이미지에 대한 `iconId`를 부여하여 해결하였습니다. 
    - 셀이 재사용되기 전 아이콘에 대한 imageView를 `nil`이 되도록 구현하였습니다.
    - `iconId`가 다른 경우 네트워크를 통해 받아온 이미지가 세팅되지 않도록 하였습니다.
    -  `iconId`가 같은 경우 여러번 이미지가 업데이트 되는 것을 방지하기 위해 이미지가 `nil`인 경우에만 이미지가 세팅되도록 만들었습니다.

5. DateFormatter 날짜표현
    - DateFormatter를 이용하여 서버에서 가져온 예보날짜를 `Date`로 변형 한 후 다시 `String`으로 변환되도록 구현하였습니다. 

&nbsp;   
## 해결하지 못한 점 && 궁금한 점
1. `MainWeatherViewController`에서 `MainWeatherTableViewCell`에 데이터를 설정해주는 방식에 대하여

```swift
//MainWeatherTableViewCell.swift 
func configure(data: WeatherForOneDay) {
        
}
```
DataSource에서 데이터를 셀에 세팅해줄 때 어떠한 방식으로 세팅시켜주는 것이 가장 적절한가요? 저희는 아래와 같은 3가지 방식들을 생각해 보았는데요!

1. 위처럼 구체적인 Model타입을 넘겨주고 셀 내부에서 필요한 데이터를 뽑아 알아서 세팅하도록 하는 방법
    - View가 Model을 직접적으로 아는 것은 부적절하다는 의견이 있음(MVC 위배)
2. 뷰 컨트롤러에서 개별적으로 데이터를 넘겨주는 방법(String이나 ImangeView를 메서드 파라미터로 일일히 넘기는 방법)
    - 또는 DataSource에서 셀의 개별 프로퍼티에 직접 접근하여 바로 설정하는 방법
    - 셀에 대한 것은 셀에서 하는 것이 맞지 않은가 하는 의견이 있음
3. 데이터를 가지고 있음을 기대할 수 있는 어떤 프로토콜을 만들어두고 이를 이용하는 방법(의존성 역전)
    - 해당 프로토콜을 준수하는 구체적인 하위 타입을 정해야함

 + `MainWeatherViewController`에서 `MainWeatherHeaderView`에 데이터를 설정해주는 방식도 일단은 위의 1번 방식을 사용하도록 설정해 두었습니다.
&nbsp;   
2. `UITableView`의 `HeaderView`에 대하여.

- 왜 이 친구는 높이를 직접 설정해줘야 하는지 모르겠습니다!
    - 동적으로 높이가 알아서 설정되도록 할 수는 없을까요? (기기별로 알아서 조절된다던지 하도록)
- 구글에서 찾아봤을 때, 다른 사람들은 `layoutIfNeeded()`를 써주던데, 이걸 꼭 써야 하는 걸까요? 
- 일단 아래의 방식을 사용하여 해결하였는데 이게 어떤 방식으로 동작하는 것인지, 다른 방법은 없는 것인지 궁금합니다.
    
  ```swift
  private func sizeHeaderViewHeightToFit() {
      guard let headerView = tableView.tableHeaderView else {
          return
      }
      let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
      var frame = headerView.frame
      frame.size.height = height
      headerView.frame = frame
  }
  //headerView에 컨텐츠가 들어갔을 때마다(address, 온도별로 따로) 매번 호출되도록 하고 있음
  ```
- 저희가 내린 결론은 일단 "커스텀 헤더 뷰 내에서 스스로의 크기를 아는 것은 소용이 없고, 외부에서 직접 테이블 뷰의 헤더뷰 크기를 지정해주어야 하는 것 같다." 인데요! 이게 맞는 걸까요? 
    &nbsp;
3. 날짜 요구사항에 맞게 `Date`를 표현하는 방법에 대하여
    - `DateFormatter.dateFormat` 설정으로 하는 것은 아닌 것 같은데... 방법을 모르겠습니다. 
    - `setLocalizedDateFormatFromTemplate`을 이용해서 별 짓을 다 해봤는데, `월/일(요일) 시간` 형식으로 출력하려면 어떻게 해야하는 것인지 모르겠습니다. 
    - 게다가 `locale`을 `.current`로 설정했는데, 기기 언어 및 지역을 한국으로 했음에도 날짜 표기가 변하지가 않네요. 왜 그런것인지.. 잘 모르겠습니다. 
&nbsp;   
4. `HeaderView`의 AutoLayout이 왜 터지는지 모르겠습니다.
모르겠습니다. 계속 콘솔에는 뭐라뭐라 나오는데 이유를 도저히 모르겠네요..!  도와주세요!!!!  🙏🥲🙏